### PR TITLE
Fix: Flexboard settings row missing on legacy Gboard settings screen

### DIFF
--- a/patches/src/main/kotlin/dev/jz6/flexboard/patches/features/settings/SettingsScreenPatch.kt
+++ b/patches/src/main/kotlin/dev/jz6/flexboard/patches/features/settings/SettingsScreenPatch.kt
@@ -3,6 +3,7 @@ package dev.jz6.flexboard.patches.features.settings
 import app.morphe.patcher.patch.ResourcePatchContext
 import app.morphe.patcher.patch.resourcePatch
 import dev.jz6.flexboard.patches.shared.Constants.COMPATIBILITY_GBOARD
+import dev.jz6.flexboard.patches.shared.Constants.GBOARD_SETTINGS_LEGACY_XML
 import dev.jz6.flexboard.patches.shared.Constants.GBOARD_SETTINGS_XML
 import dev.jz6.flexboard.patches.shared.Constants.SETTINGS_FRAGMENT_CLASS
 import dev.jz6.flexboard.patches.shared.androidAttribute
@@ -101,15 +102,17 @@ internal val settingsScreenPatch = resourcePatch(
             "FLEXBOARD_VERSION" to readVersion(),
         ))
 
-        document(GBOARD_SETTINGS_XML).use { settings ->
-            settings.addFlexboardEntry()
+        // Both top-level screens: Gboard picks between them at runtime (SettingsActivity.t()), and
+        // the legacy one is what ColorOS/OxygenOS and any pre-36 device actually show. Adding the
+        // row to only the modern screen left it invisible on exactly those devices.
+        for (screen in listOf(GBOARD_SETTINGS_XML, GBOARD_SETTINGS_LEGACY_XML)) {
+            document(screen).use { it.addFlexboardEntry(screen) }
         }
     }
 }
 
 private const val PREFERENCE_SCREEN_TAG = "PreferenceScreen"
 private const val PREFERENCE_CATEGORY_TAG = "androidx.preference.PreferenceCategory"
-private const val FOOTER_PREFERENCE_TAG = "com.android.settingslib.widget.FooterPreference"
 
 /**
  * The row whose icon Flexboard uses, and the Flexboard screen's row widget on the other side.
@@ -194,10 +197,10 @@ private fun readVersion(): String {
     return text
 }
 
-private fun Document.addFlexboardEntry() {
+private fun Document.addFlexboardEntry(screen: String) {
     val root = documentElement
     check(root.tagName == PREFERENCE_SCREEN_TAG) {
-        "$GBOARD_SETTINGS_XML has root <${root.tagName}>, expected <$PREFERENCE_SCREEN_TAG> — " +
+        "$screen has root <${root.tagName}>, expected <$PREFERENCE_SCREEN_TAG> — " +
             "Gboard's settings are no longer the androidx screen this patch appends to"
     }
 
@@ -216,22 +219,16 @@ private fun Document.addFlexboardEntry() {
         setAndroidAttribute("fragment", SETTINGS_FRAGMENT_CLASS)
     }
 
-    // First row of the first category, so it opens at the top of the screen rather than buried
-    // down beside About. Inside a category rather than above one, because a row that is a direct
-    // child of the screen renders without the inset and grouping every other row has.
+    // Top of the screen either way. The modern screen groups its rows into categories, so the row
+    // goes first in the first category — inside one rather than above it, because a row that is a
+    // direct child of a categorised screen renders without the inset and grouping the others have.
+    // The legacy screen has no categories at all: its rows are direct children of the root, so the
+    // row goes first there too, where it shares exactly the styling of every sibling.
     //
     // `insertBefore(entry, firstChild)` is deliberate over building an index: `firstChild` may be
     // a whitespace text node, and inserting ahead of it still lands at position zero — while a
-    // null firstChild (an empty category) makes this an append, which is the right answer there
-    // too.
-    //
-    // Appending to the root is what the fallbacks avoid: it would land the row *after* the
-    // footer, reading as a stray control rather than a settings entry.
+    // null firstChild (an empty parent) makes this an append, which is the right answer there too.
     val category = root.childElements(PREFERENCE_CATEGORY_TAG).firstOrNull()
-    val footer = root.childElements(FOOTER_PREFERENCE_TAG).firstOrNull()
-    when {
-        category != null -> category.insertBefore(entry, category.firstChild)
-        footer != null -> root.insertBefore(entry, footer)
-        else -> root.appendChild(entry)
-    }
+    val parent = category ?: root
+    parent.insertBefore(entry, parent.firstChild)
 }

--- a/patches/src/main/kotlin/dev/jz6/flexboard/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/dev/jz6/flexboard/patches/shared/Constants.kt
@@ -26,6 +26,15 @@ internal object Constants {
     const val GBOARD_SETTINGS_XML = "res/xml/settings.xml"
 
     /**
+     * Gboard's legacy top-level settings screen. `SettingsActivity.t()` inflates this one instead
+     * of [GBOARD_SETTINGS_XML] whenever the "expressive design" gate is off — which it is on
+     * `SDK_INT < 36` and on Android 16 devices whose OEM does not set `is_expressive_design_enabled`
+     * (ColorOS/OxygenOS among them). The row must be added to both screens or it goes missing on
+     * exactly those devices. Keeps its real name like the modern screen does.
+     */
+    const val GBOARD_SETTINGS_LEGACY_XML = "res/xml/settings_legacy.xml"
+
+    /**
      * Signatures and target carried over verbatim from the build this was developed against.
      * The hooks are pinned to exactly one Gboard build; anything else must fail to match rather
      * than patch something it does not understand.

--- a/tools/apk/check_patch_resources.py
+++ b/tools/apk/check_patch_resources.py
@@ -118,9 +118,8 @@ SETTINGS_ROW_ATTRS = [
     ("icon", "@drawable/flexboard_settings_icon"),
     ("fragment", "dev.jz6.flexboard.extension.settings.FlexboardSettingsFragment"),
 ]
-SETTINGS_SCREEN_FILE = "res/xml/settings.xml"
+SETTINGS_SCREEN_FILES = ["res/xml/settings.xml", "res/xml/settings_legacy.xml"]
 PREFERENCE_CATEGORY_TAG = "androidx.preference.PreferenceCategory"
-FOOTER_PREFERENCE_TAG = "com.android.settingslib.widget.FooterPreference"
 
 
 def fail(stage, message):
@@ -299,30 +298,26 @@ def replay(scratch):
             # arsclib sees it; without a <public> entry the encoder rejects the reference.
             define_public_id(pkg_dir, target.removeprefix("res/"), source.name.split(".")[0])
 
-    # The settings row insert, mirroring Document.addFlexboardEntry().
-    settings = pkg_dir / SETTINGS_SCREEN_FILE
-    tree = ET.parse(settings)
-    root = tree.getroot()
-    if root.tag != "PreferenceScreen":
-        fail("replay", f"settings.xml root <{root.tag}> is not <PreferenceScreen>")
+    # The settings row insert, mirroring Document.addFlexboardEntry() — onto both the modern and
+    # the legacy top-level screen, because Gboard picks between them per device.
     a = lambda k: f"{{{ANDROID_NS}}}{k}"
-    have = any(e.get(a("key")) == "flexboard_settings" for e in root.iter())
-    if not have:
-        row = ET.Element(SETTINGS_ROW_TAG)
-        for k, v in SETTINGS_ROW_ATTRS:
-            row.set(a(k), v)
-        category = next((c for c in root if c.tag == PREFERENCE_CATEGORY_TAG), None)
-        footer = next((c for c in root if c.tag == FOOTER_PREFERENCE_TAG), None)
-        if category is not None:
-            category.insert(0, row)
-        elif footer is not None:
-            root.insert(list(root).index(footer), row)
-        else:
-            root.append(row)
-        write_fresh(settings, "<?xml version='1.0' encoding='utf-8'?>\n"
-                              + ET.tostring(root, encoding="unicode"))
-        dom_parse(settings)
-        touched.append(settings)
+    for screen_file in SETTINGS_SCREEN_FILES:
+        settings = pkg_dir / screen_file
+        tree = ET.parse(settings)
+        root = tree.getroot()
+        if root.tag != "PreferenceScreen":
+            fail("replay", f"{screen_file} root <{root.tag}> is not <PreferenceScreen>")
+        have = any(e.get(a("key")) == "flexboard_settings" for e in root.iter())
+        if not have:
+            row = ET.Element(SETTINGS_ROW_TAG)
+            for k, v in SETTINGS_ROW_ATTRS:
+                row.set(a(k), v)
+            category = next((c for c in root if c.tag == PREFERENCE_CATEGORY_TAG), None)
+            (category if category is not None else root).insert(0, row)
+            write_fresh(settings, "<?xml version='1.0' encoding='utf-8'?>\n"
+                                  + ET.tostring(root, encoding="unicode"))
+            dom_parse(settings)
+            touched.append(settings)
 
     # Values merges (empty by policy today; see VALUE_MERGES).
     values_dir = REPO / "patches" / "src" / "main" / "resources" / "values"


### PR DESCRIPTION
Gboard picks between `settings.xml` (modern) and `settings_legacy.xml` (legacy) at runtime via `SettingsActivity.t();` devices without expressive design (e.g. ColorOS/OxygenOS on Android 16) get the legacy screen. The patch only added the row to the modern screen, so it was invisible there.

Fix: add the row to both screens, at the top of each (first in the first category on modern; first child of root on legacy). Updated `check_patch_resources.py` to match. Verified with aapt2 and on an Oppo Find X9 (Android 16).

Should fix https://github.com/JZ6/Flexboard/issues/2

Tested on ColorOS 16 (Android 16):

<img width="1256" height="1039" alt="image" src="https://github.com/user-attachments/assets/aa767d70-6112-445f-98fa-90d76467198b" />